### PR TITLE
Add Wayland requirements and auto AppIndicator backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Replaced default .ico with a gradient-based USB/monitor icon for better visibili
 - Python 3.12
 - `ddcutil` command line tool
 - Python modules from `linux/requirements.txt`
+- `python3-gi` and an AppIndicator library such as `libayatana-appindicator3` are required when running under Wayland
 
 ## Installation
 

--- a/linux/requirements.txt
+++ b/linux/requirements.txt
@@ -1,3 +1,4 @@
 pyudev
 pystray
 pillow
+PyGObject

--- a/linux/usb_monitor.py
+++ b/linux/usb_monitor.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 import os
+
+# Use AppIndicator backend under Wayland for tray icon support
+if os.environ.get("XDG_SESSION_TYPE") == "wayland":
+    os.environ.setdefault("PYSTRAY_BACKEND", "appindicator")
+
 import sys
 import time
 import json


### PR DESCRIPTION
## Summary
- note `python3-gi` and an AppIndicator library needed when running Wayland
- include `PyGObject` in Linux requirements
- automatically set `PYSTRAY_BACKEND=appindicator` on Wayland

## Testing
- `python3 -m py_compile linux/usb_monitor.py`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868d53573f0832bb10f4df61184fa4f