### PR TITLE
Update linux icon and log viewer

### DIFF
--- a/linux/install_service.sh
+++ b/linux/install_service.sh
@@ -5,7 +5,7 @@ TARGET_DIR=/opt/usbmonitor
 sudo mkdir -p "$TARGET_DIR"
 
 sudo cp linux/usb_monitor.py "$TARGET_DIR/usb_monitor.py"
-sudo cp monitornew.ico "$TARGET_DIR/monitornew.ico"
+sudo cp linux/monitor.png "$TARGET_DIR/monitor.png"
 sudo cp linux/requirements.txt "$TARGET_DIR/requirements.txt"
 
 sudo cp linux/systemd/usb_monitor.service /etc/systemd/system/usb_monitor.service

--- a/linux/usb_monitor.py
+++ b/linux/usb_monitor.py
@@ -55,7 +55,7 @@ def log_event(message: str):
 
 def open_log_file():
     if os.path.exists(LOG_FILE):
-        subprocess.Popen(["xdg-open", LOG_FILE])
+        subprocess.Popen(["kwrite", LOG_FILE])
     else:
         messagebox.showinfo("USB Monitor", "Log file not found.")
 
@@ -202,7 +202,7 @@ def main_loop():
 
 def create_tray_icon():
     global icon
-    icon_path = os.path.join(os.path.dirname(__file__), "..", "monitornew.ico")
+    icon_path = os.path.join(os.path.dirname(__file__), "monitor.png")
     try:
         image = Image.open(icon_path)
     except Exception:


### PR DESCRIPTION
## Summary
- set monitor.png as the tray icon on Linux
- open the log file with KWrite from the tray menu
- update installer script to ship monitor.png

## Testing
- `python3 -m py_compile usb_monitor.py linux/usb_monitor.py device_checker.py`

------
https://chatgpt.com/codex/tasks/task_e_6868f5e7a988832ba8b054b0281778b5